### PR TITLE
fix(etl): resolve author terms through the guest author export

### DIFF
--- a/App.py
+++ b/App.py
@@ -50,6 +50,11 @@ class Pipeline:
             "gAuth": GuestAuthorTranslator(extracted["guestAuth"]),
             "auth": AuthorTranslator(extracted["auth"]),
         }
+        # The same resolution the fused path performs, so the two cannot
+        # disagree about who wrote an article.
+        translators["articles"].guestAuthorNames = Extractor.buildGuestAuthorNameMap(
+            Utility.resolveExportZipMembers(ZIP_FILE)[1]
+        )
         self.on_start("Translating...")
         try:
             translators["auth"].translate(on_progress=self.on_start)

--- a/Extractor.py
+++ b/Extractor.py
@@ -63,6 +63,38 @@ _GUEST_AUTHOR_META_KEYS = frozenset((
 
 
 class Extractor:
+  @staticmethod
+  def buildGuestAuthorNameMap(source):
+    """Map a guest author's term slug to their real display name.
+
+    A post credits a guest author with
+    `<category domain="author" nicename="cap-beeboop">beeboop</category>`,
+    where the element text is the SLUG, not the name. When the slug resembles
+    the name ("michael-duffin") the matcher still finds the author, but when it
+    is a handle it cannot: `cap-beeboop` is Michael Davis, and all ten of his
+    articles arrived with no byline. Only the guest author export carries the
+    real name, so it is the authority for this mapping.
+    """
+    names = {}
+    try:
+      with Extractor._openXml(source) as handle:
+        context = etree.iterparse(handle, events=("end",), tag=("item",), recover=True)
+        for _, elem in context:
+          slug = elem.findtext(f"{{{_WP_NS}}}post_name")
+          title = elem.findtext("title")
+          if slug and title and title.strip():
+            names.setdefault(slug.strip(), title.strip())
+          elem.clear()
+          parent = elem.getparent()
+          if parent is not None:
+            while elem.getprevious() is not None:
+              del parent[0]
+    except Exception:
+      # A missing or unreadable guest author export must not take down the
+      # whole run; without the map the previous term-text behaviour applies.
+      return {}
+    return names
+
   def __init__(self, posts, guestAuths):
     self.postsFile = posts
     self.guestAuthsFile = guestAuths
@@ -344,6 +376,12 @@ class Extractor:
     def progress(msg):
       if on_progress:
         on_progress(msg)
+
+    # Built first: posts are translated before the guest authors are parsed, so
+    # without this pre-pass an article's author term cannot be resolved to a
+    # real name at the point it is needed.
+    progress("indexing guest author names")
+    translators["articles"].guestAuthorNames = self.buildGuestAuthorNameMap(self.guestAuthsFile)
 
     progress("parsing/translating wp-posts.xml")
     self._translatePosts(self.postsFile, translators["articles"], translators["auth"])

--- a/Translator/ArticleTranslator.py
+++ b/Translator/ArticleTranslator.py
@@ -7,10 +7,13 @@ import re
 
 _IMG_UPLOAD_PATTERN = re.compile(r"wp-content\/uploads\/(.*?)\\")
 
-class ArticleTranslator(Translator):  
+class ArticleTranslator(Translator):
   # Constructor
   def __init__(self, incomingData):
     super().__init__(incomingData)
+    # {guest author term slug -> real display name}, supplied by the Extractor.
+    # Empty is valid: resolution then falls back to the term's own text.
+    self.guestAuthorNames = {}
 
   def _getArticleData(self, data):
     text = str(U._html_text_norm(data.get('content:encoded', Article.defaultValue))).replace('"', '\\"')
@@ -103,6 +106,7 @@ class ArticleTranslator(Translator):
         if not isinstance(tagData, dict):
           continue
 
+        nicename = tagData.get("@nicename", Article.defaultValue)
         domain = tagData.get("@domain", Article.defaultValue)
         text = U._html_text_norm(tagData.get("#text", Article.defaultValue))
 
@@ -118,9 +122,12 @@ class ArticleTranslator(Translator):
         elif (domain == "category" and text is not None and text != Article.defaultValue):
           resultCategories.append(text)
         elif (domain == "author"):
-          cleanName = text.translate(str.maketrans('', '', '.-_ ')).lower()
+          # The term's text is the slug ("beeboop"), not the byline. Resolve it
+          # through the guest author export, which holds the real name.
+          resolved = self.guestAuthorNames.get(nicename, text)
+          cleanName = resolved.translate(str.maketrans('', '', '.-_ ')).lower()
           obj["authorCleanNames"].append(cleanName)
-          obj["authors"].append(text)
+          obj["authors"].append(resolved)
 
     except (KeyError, TypeError):
       resultTags.append('NO_TAGS')

--- a/tests/test_guest_author_names.py
+++ b/tests/test_guest_author_names.py
@@ -1,0 +1,72 @@
+"""Tests for resolving a post's author term to the real guest author name.
+
+Run from the repo root:
+
+    .venv/bin/python -m unittest tests.test_guest_author_names
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from Translator.ArticleTranslator import ArticleTranslator
+
+
+def author_term(nicename, text):
+    return {"@domain": "author", "@nicename": nicename, "#text": text}
+
+
+def article_obj(terms, text="x" * 200, title="A title"):
+    return {
+        "tags": terms,
+        "categories": [],
+        "text": text,
+        "title": title,
+        "authors": [],
+        "authorCleanNames": [],
+    }
+
+
+class ResolveAuthorTerms(unittest.TestCase):
+    def setUp(self):
+        self.translator = ArticleTranslator([])
+
+    def test_slug_handle_resolves_to_real_name(self):
+        # The regression: the term text is the slug, and this slug looks
+        # nothing like the name, so the article used to end up with no byline.
+        self.translator.guestAuthorNames = {"cap-beeboop": "Michael Davis"}
+        obj = article_obj([author_term("cap-beeboop", "beeboop")])
+        self.translator._processTags(obj)
+        self.assertEqual(obj["authors"], ["Michael Davis"])
+        self.assertEqual(obj["authorCleanNames"], ["michaeldavis"])
+
+    def test_accented_name_comes_from_the_export_not_the_slug(self):
+        self.translator.guestAuthorNames = {
+            "cap-maria-paula-mijares": "María Paula Mijares"
+        }
+        obj = article_obj([author_term("cap-maria-paula-mijares", "maria-paula-mijares")])
+        self.translator._processTags(obj)
+        self.assertEqual(obj["authors"], ["María Paula Mijares"])
+
+    def test_falls_back_to_term_text_when_unmapped(self):
+        self.translator.guestAuthorNames = {}
+        obj = article_obj([author_term("cap-someone", "Some One")])
+        self.translator._processTags(obj)
+        self.assertEqual(obj["authors"], ["Some One"])
+
+    def test_multiple_authors_each_resolve(self):
+        self.translator.guestAuthorNames = {
+            "cap-beeboop": "Michael Davis",
+            "cap-carter": "Carter Blake",
+        }
+        obj = article_obj([
+            author_term("cap-beeboop", "beeboop"),
+            author_term("cap-carter", "carter"),
+        ])
+        self.translator._processTags(obj)
+        self.assertEqual(obj["authors"], ["Michael Davis", "Carter Blake"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A post credits a guest author with

  <category domain="author" nicename="cap-beeboop">beeboop</category>

and _processTags took the element TEXT as the byline. That text is the term slug, not the name. Where the slug resembles the name ("michael-duffin") the matcher still finds the author, so this looked fine -- but where the slug is a handle it matches nobody and the article is published with no byline at all.

cap-beeboop is Michael Davis. All ten of his articles came through authorless, which is how this was found. Across the August 2026 export 157 posts are affected, by four patterns: handles (beeboop -> Michael Davis, carter -> Carter Blake), slugs that drop accents (maria-paula-mijares -> María Paula Mijares), names with a middle initial or suffix (charlotte-nelson -> Charlotte J. Nelson), and slug/name typos (krishna-thacker -> Krishna Thaker).

Only the guest author export carries the real name, so it is the authority. Extractor.buildGuestAuthorNameMap indexes it, and the term is resolved through that map with the old text as the fallback. The map has to be built before posts are translated, because posts are translated first -- hence the pre-pass rather than reusing the parsed guest author records. Both the fused and the split extract/translate paths set it, so they cannot disagree about who wrote an article.