### PR TITLE
fix(etl): re-resolve the author cache by name, and dedupe repeated bylines

### DIFF
--- a/Sanitizer/ArticleAuthorMatcher.py
+++ b/Sanitizer/ArticleAuthorMatcher.py
@@ -70,12 +70,48 @@ class ArticleAuthorMatcher(Sanitizer):
 
         self._applyMatches()
 
+    def _resolveCachedMatch(self, name):
+        """A cached decision, re-resolved against the CURRENT export's authors.
+
+        The cache stores (author_id, display_name), but WordPress renumbers
+        authors between exports, so the stored id routinely belongs to somebody
+        else next time. Ava Buckingham was 554 and is now 553 (that id no longer
+        exists, so her articles lost their author); Mary Elizabeth Hoffman was
+        338, and 338 is now Snehal Yarlagadda -- silently crediting her articles
+        to a different person, which no integrity check catches because the row
+        does exist.
+
+        The cached decision means "this byline is that PERSON", so the name is
+        what carries over and the id is looked up fresh. If the person is not in
+        this export at all, returns None so the caller falls through to normal
+        resolution rather than trusting a dead id.
+        """
+        entry = self.resolution_cache.get(name)
+        if not entry:
+            return None
+        try:
+            _, cachedName = entry
+        except (TypeError, ValueError):
+            return None
+        if not cachedName:
+            return None
+
+        key = Utility.cleanDocument(cachedName, "similarity")
+        current = self.policies._author_lookup.get(key) if key else None
+        if current is None:
+            return None
+        return current
+
     def _manualResolve(self, flagged: list, select_author=None):
         for i, item in enumerate(flagged):
             aid, name, cands = item["article_id"], item["author_name"], item["candidates"]
 
-            if name in self.resolution_cache:
-                author_id, dname = self.resolution_cache[name]
+            cached = self._resolveCachedMatch(name)
+            if cached is not None:
+                author_id, dname = cached
+                # Refresh so the cache heals itself instead of carrying a stale
+                # id forward into every future run.
+                self.resolution_cache[name] = (author_id, dname)
                 self.author_matches.setdefault(aid, {})[name] = (author_id, dname)
                 self._logChange(aid, name, dname)
                 continue
@@ -108,14 +144,21 @@ class ArticleAuthorMatcher(Sanitizer):
             
             matches = self.author_matches.get(data.get("id", "unknown"), {})
             ids, names = [], []
-            
+            # A byline that names the same person twice must still produce one
+            # link: articles_authors has no unique constraint, so a repeat wrote
+            # a duplicate row and the byline rendered the name twice.
+            seen = set()
+
             for name in (data.get("authorCleanNames") or []):
                 if name in matches:
                     match = matches[name]
                     entries = match if isinstance(match, list) else [match]
                     for aid, dname in entries:
+                        if aid in seen:
+                            continue
+                        seen.add(aid)
                         ids.append(aid)
                         names.append(dname)
-            
+
             data["authorIDs"] = ids
             data["authors"] = names

--- a/tests/test_article_author_links.py
+++ b/tests/test_article_author_links.py
@@ -1,0 +1,91 @@
+"""Tests for article->author link building.
+
+Run from the repo root:
+
+    .venv/bin/python -m unittest tests.test_article_author_links
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from Sanitizer.ArticleAuthorMatcher import ArticleAuthorMatcher
+
+
+AUTHORS = [
+    {"id": 553, "display_name": "Ava Buckingham", "login": "ava-buckingham"},
+    {"id": 343, "display_name": "Mary Elizabeth Hoffman", "login": "mary-elizabeth-hoffman"},
+    {"id": 338, "display_name": "Snehal Yarlagadda", "login": "snehal-yarlagadda"},
+    {"id": 32, "display_name": "Shreya Srinivasan", "login": "shreya-srinivasan"},
+]
+
+
+def matcher(articles=None, cache=None):
+    m = ArticleAuthorMatcher(articles or [], AUTHORS)
+    m.resolution_cache = cache or {}
+    return m
+
+
+class ResolveCachedMatch(unittest.TestCase):
+    def test_stale_id_is_reresolved_by_name(self):
+        # Ava Buckingham was 554 in the export this was answered against; she is
+        # 553 now, and 554 exists nowhere, so trusting it orphaned 9 links.
+        m = matcher(cache={"abuckingham": (554, "Ava Buckingham")})
+        self.assertEqual(m._resolveCachedMatch("abuckingham"), (553, "Ava Buckingham"))
+
+    def test_reused_id_does_not_credit_the_wrong_person(self):
+        # The dangerous case: 338 was Hoffman, and in this export 338 is a
+        # different real person. The row exists, so no integrity check catches
+        # it -- her articles simply get his name.
+        m = matcher(cache={"elizabethhoffman": (338, "Mary Elizabeth Hoffman")})
+        resolved = m._resolveCachedMatch("elizabethhoffman")
+        self.assertEqual(resolved, (343, "Mary Elizabeth Hoffman"))
+        self.assertNotEqual(resolved[0], 338)
+
+    def test_person_absent_from_this_export_falls_through(self):
+        m = matcher(cache={"someone": (900, "Someone Gone")})
+        self.assertIsNone(m._resolveCachedMatch("someone"))
+
+    def test_uncached_name_returns_none(self):
+        self.assertIsNone(matcher()._resolveCachedMatch("nobody"))
+
+    def test_malformed_entry_returns_none(self):
+        m = matcher(cache={"bad": None, "worse": (1,)})
+        self.assertIsNone(m._resolveCachedMatch("bad"))
+        self.assertIsNone(m._resolveCachedMatch("worse"))
+
+
+class ApplyMatches(unittest.TestCase):
+    def test_repeated_byline_produces_one_link(self):
+        # articles_authors has no unique constraint, so a doubled byline wrote
+        # two identical rows and rendered the name twice.
+        article = {
+            "id": 7715,
+            "authorCleanNames": ["shreyasrinivasan", "shreyasrinivasan"],
+        }
+        m = matcher([article])
+        m.author_matches = {7715: {"shreyasrinivasan": (32, "Shreya Srinivasan")}}
+        m._applyMatches()
+        self.assertEqual(article["authorIDs"], [32])
+        self.assertEqual(article["authors"], ["Shreya Srinivasan"])
+
+    def test_distinct_coauthors_are_both_kept(self):
+        article = {
+            "id": 1,
+            "authorCleanNames": ["avabuckingham", "shreyasrinivasan"],
+        }
+        m = matcher([article])
+        m.author_matches = {
+            1: {
+                "avabuckingham": (553, "Ava Buckingham"),
+                "shreyasrinivasan": (32, "Shreya Srinivasan"),
+            }
+        }
+        m._applyMatches()
+        self.assertEqual(article["authorIDs"], [553, 32])
+        self.assertEqual(article["authors"], ["Ava Buckingham", "Shreya Srinivasan"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two defects that both wrote bad rows into `articles_authors`. Found while verifying a full CMS reseed — both had been patched by hand on the live database; this fixes them at source so the patches are no longer needed.

## 1. Stale ids in the resolution cache

`_manualResolve` trusted the `author_id` stored in `article_author_resolution_cache.json`. **WordPress renumbers authors between exports**, so that id routinely belongs to someone else on the next run. The cache is currently carrying three stale ids:

```
'abuckingham':      [554, 'Ava Buckingham']         # she is 553 now
'elizabethhoffman': [338, 'Mary Elizabeth Hoffman'] # 338 is Snehal Yarlagadda now
'roxanashaojaian':  [437, 'Roxana Shojaian']        # 437 is Nicole Clifford now
```

Two failure modes, and the second is the dangerous one:

- **Missing id → no byline.** 554 exists nowhere, so Ava Buckingham's 9 articles linked to a non-existent author and rendered with no byline at all. This *is* detectable (`LEFT JOIN authors ... WHERE au.id IS NULL`).
- **Reused id → wrong author, silently.** 338 exists — as a different person. Hoffman's articles were credited to Snehal Yarlagadda. **No integrity check catches this**, because the row is perfectly valid. 4 articles were affected on the August 2026 export (against Snehal Yarlagadda, Nicolena Stiles, Nicole Clifford).

A cached decision means "this byline is that **person**", so the name is what carries over. The id is now looked up fresh against the current export, and the entry is rewritten so the cache heals rather than carrying the stale id forward forever. If the person is absent from this export the cache no longer answers at all, and the run falls through to normal resolution instead of emitting a dead id.

## 2. Repeated bylines wrote duplicate links

`_applyMatches` appended one link per `authorCleanNames` entry, so an article whose byline named the same person twice wrote **two identical `articles_authors` rows** — the table has no unique constraint — and rendered the name twice. Ids are now de-duplicated per article with order preserved, so genuine co-authors are unaffected.

## Testing

New `tests/test_article_author_links.py` — 7 tests: stale-id re-resolution, the reused-id case asserting the wrong person is *not* credited, fall-through when the person is absent, malformed cache entries, the repeated-byline dedupe, and distinct co-authors surviving it. All 9 modules pass.

Verified by regenerating against the real August 2026 export:

| | before | after |
|---|---|---|
| referenced author ids missing from `authors` | `[554]` | none |
| duplicate (author, article) pairs | 2 | 0 |
| Ava Buckingham links | 33 on 553 + 9 on 554 | 42 on 553 |
| link rows | 7670 | 7668 |

Hoffman's articles now link to 343 rather than Snehal Yarlagadda's 338.

🤖 Generated with [Claude Code](https://claude.com/claude-code)