### PR TITLE
feat(etl): seed CMS-owned embeddings with bge-small and a source hash

### DIFF
--- a/Formatter/ArticleEmbeddingsFormatter.py
+++ b/Formatter/ArticleEmbeddingsFormatter.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import hashlib
+import html
 import re
 from pathlib import Path
 from typing import Any
@@ -12,6 +14,23 @@ class EmbeddingsDependencyError(RuntimeError):
 
 
 class ArticleEmbeddingsFormatter(Formatter):
+    """Bulk-loads vectors for the migrated archive.
+
+    The CMS owns this table now: it creates it, and a background reconciler
+    fills in anything missing or stale (see server/internal/embeddings). This
+    formatter exists only because embedding ~30k archived articles in one batched
+    process is far faster than draining them through the sidecar a batch at a
+    time. It is an optimization, not the source of truth -- which is why it no
+    longer drops the table, and why the CMS is correct without it.
+
+    Two things here MUST match the CMS or the reconciler will fight this
+    formatter, re-embedding the whole archive after every reseed:
+
+      * ``_embedding_source`` must produce byte-identical text to
+        ``BuildEmbeddingSource`` in server/internal/database/article_embeddings.go.
+      * ``--embedding-model`` must be the sidecar's ``EMBED_MODEL``.
+    """
+
     def __init__(self, articleData, model: str, batch_size: int, max_chars: int):
         super().__init__(articleData)
         self.model = model
@@ -26,9 +45,26 @@ class ArticleEmbeddingsFormatter(Formatter):
 
     @staticmethod
     def _strip_html(text: str) -> str:
-        cleaned = re.sub(r"<[^>]+>", " ", text)
-        cleaned = re.sub(r"\s+", " ", cleaned)
-        return cleaned.strip()
+        """Mirror of stripHTMLForEmbedding in the CMS.
+
+        The order matters and is part of the contract: replace tags with a
+        space, *then* unescape entities, *then* collapse whitespace. Unescaping
+        first would let an escaped &lt;b&gt; become a tag and get stripped.
+        """
+        cleaned = re.sub(r"<[^>]*>", " ", text)
+        cleaned = html.unescape(cleaned)
+        return " ".join(cleaned.split())
+
+    def _embedding_source(self, row: dict[str, Any]) -> str:
+        """Mirror of BuildEmbeddingSource in the CMS. Keep the two in step."""
+        parts = [
+            str(row.get("title") or "").strip(),
+            str(row.get("tags") or "").strip(),
+            self._strip_html(str(row.get("text") or "")).strip(),
+        ]
+        blob = "\n\n".join(part for part in parts if part)
+        # Truncate by character, matching the CMS's rune-wise cut.
+        return blob[: self.max_chars]
 
     def _normalize_articles(self) -> list[dict[str, Any]]:
         normalized: list[dict[str, Any]] = []
@@ -45,14 +81,17 @@ class ArticleEmbeddingsFormatter(Formatter):
             except (TypeError, ValueError):
                 continue
 
-            title = str(row.get("title") or "").strip()
-            description = str(row.get("description") or "").strip()
-            text = str(row.get("text") or "").strip()
-            blob = "\n\n".join(part for part in (title, description, self._strip_html(text)) if part)
+            blob = self._embedding_source(row)
             if not blob:
                 continue
 
-            normalized.append({"id": article_id, "text": blob})
+            normalized.append(
+                {
+                    "id": article_id,
+                    "text": blob,
+                    "hash": hashlib.sha256(blob.encode("utf-8")).hexdigest(),
+                }
+            )
 
         normalized.sort(key=lambda x: x["id"])
         return normalized
@@ -73,35 +112,53 @@ class ArticleEmbeddingsFormatter(Formatter):
         out_sql.parent.mkdir(parents=True, exist_ok=True)
 
         if not articles:
-            out_sql.write_text(
-                "DROP TABLE IF EXISTS article_embeddings;\n-- No articles to embed.\n",
-                encoding="utf-8",
-            )
+            out_sql.write_text("-- No articles to embed.\n", encoding="utf-8")
             return
 
         model_obj = SentenceTransformer(self.model, device="cpu")
-        corpus = [row["text"][: self.max_chars] for row in articles]
+        corpus = [row["text"] for row in articles]
         vectors = model_obj.encode(
             corpus,
             batch_size=self.batch_size,
             convert_to_numpy=True,
-            normalize_embeddings=False,
+            # MariaDB ranks these by euclidean distance, which only agrees with
+            # cosine similarity on unit vectors. Left unnormalized, a long
+            # article's larger magnitude skewed every ranking it appeared in.
+            normalize_embeddings=True,
             show_progress_bar=True,
         )
         dim = int(vectors.shape[1])
 
         with out_sql.open("w", encoding="utf-8") as handle:
-            handle.write(f"DROP TABLE IF EXISTS {table};\n")
+            # No DROP. This table is CMS-owned (see
+            # server/internal/database/schema/article_embeddings.sql); dropping it
+            # here is what used to wipe every vector written since the last
+            # reseed. CREATE IF NOT EXISTS covers loading this seed into an empty
+            # database before the CMS has ever started.
             handle.write(
-                f"CREATE TABLE {table} (\n"
-                f"  article_id BIGINT PRIMARY KEY,\n"
+                f"CREATE TABLE IF NOT EXISTS {table} (\n"
+                f"  article_id BIGINT NOT NULL PRIMARY KEY,\n"
                 f"  embedding VECTOR({dim}) NOT NULL,\n"
+                f"  source_hash CHAR(64) NOT NULL DEFAULT '',\n"
+                f"  model VARCHAR(128) NOT NULL DEFAULT '',\n"
+                f"  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,\n"
                 f"  VECTOR INDEX (embedding) DISTANCE=euclidean\n"
-                f");\n"
+                f") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;\n"
             )
+            model_sql = self.model.replace("\\", "\\\\").replace("'", "\\'")
             for row, vec in zip(articles, vectors, strict=True):
                 vector_text = self._vec_to_text(vec.tolist())
+                # The hash and model name are what let the CMS reconciler tell
+                # "already embedded with the current model" from "needs work".
+                # Without them every seeded row looks unattributed and the
+                # archive gets re-embedded through the sidecar after each reseed.
+                #
+                # ON DUPLICATE KEY UPDATE, because a reseed now loads into a
+                # table the CMS may already have populated.
                 handle.write(
-                    f"INSERT INTO {table} (article_id, embedding) VALUES "
-                    f"({row['id']}, VEC_FromText('{vector_text}'));\n"
+                    f"INSERT INTO {table} (article_id, embedding, source_hash, model) VALUES "
+                    f"({row['id']}, VEC_FromText('{vector_text}'), '{row['hash']}', '{model_sql}') "
+                    f"ON DUPLICATE KEY UPDATE embedding = VALUES(embedding), "
+                    f"source_hash = VALUES(source_hash), model = VALUES(model), "
+                    f"updated_at = CURRENT_TIMESTAMP;\n"
                 )

--- a/main.py
+++ b/main.py
@@ -42,8 +42,15 @@ def parse_args():
     )
     parser.add_argument(
         "--embedding-model",
-        default=os.getenv("WP_EMBED_MODEL", "sentence-transformers/paraphrase-MiniLM-L3-v2"),
-        help="SentenceTransformer model name",
+        # Must match the CMS embedding sidecar's EMBED_MODEL. A distance between
+        # vectors from two different models is meaningless, so a mismatch here
+        # degrades search ranking and "related articles" silently rather than
+        # failing. Was paraphrase-MiniLM-L3-v2, a symmetric paraphrase model;
+        # bge-small-en-v1.5 is trained for query-to-document retrieval, which is
+        # what search actually does. Both are 384-dimensional, so VECTOR(384) is
+        # unchanged.
+        default=os.getenv("WP_EMBED_MODEL", "BAAI/bge-small-en-v1.5"),
+        help="SentenceTransformer model name; must match the CMS sidecar's EMBED_MODEL",
     )
     parser.add_argument(
         "--embedding-batch-size",

--- a/tests/test_article_embeddings.py
+++ b/tests/test_article_embeddings.py
@@ -1,0 +1,117 @@
+"""Tests for ArticleEmbeddingsFormatter's embedding source. Run from the repo root:
+
+    .venv/bin/python -m unittest tests.test_article_embeddings
+
+These do not load a model -- they pin the *text* that gets embedded, which is the
+half that has to agree with the CMS.
+"""
+import hashlib
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from Formatter.ArticleEmbeddingsFormatter import ArticleEmbeddingsFormatter
+
+MAX_CHARS = 5000
+
+# The CMS reconciler decides an article needs re-embedding by comparing this hash
+# to the one stored beside the vector. This formatter seeds the migrated archive
+# with rows the CMS did not write, so both sides must derive the hash from
+# byte-identical text -- otherwise every seeded row reads as stale and the whole
+# archive is re-embedded through the sidecar after each reseed.
+#
+# The identical table lives in the CMS at
+# server/internal/database/article_embeddings_test.go. Changing one without the
+# other breaks the contract; that is exactly what these goldens catch.
+GOLDENS = [
+    (
+        "tags and entity-decoded body",
+        {"title": "Tuition freeze", "tags": "campus,money",
+         "text": "<p>Hello &amp; welcome</p><div>world</div>"},
+        "ef099c229d1e5a3b4541abe9c57491b2467711de61aab5124bc1724dc7f9bcbd",
+        51,
+    ),
+    (
+        "empty parts are dropped, not joined as blanks",
+        {"title": "  Spaced  ", "tags": "", "text": "<p>a</p>\n\n<p>b</p>"},
+        "55b414e3ba68401d30466d433fa01cbf79a3352cc2cfd5ae5c379ae8541d9013",
+        11,
+    ),
+    (
+        "non-ASCII survives intact",
+        {"title": "Unicode café — naïve", "tags": "résumé", "text": "<p>éèê x</p>"},
+        "dc79ead758b72f0e0cf244f00c419fde0eb64b78ad288d18e0dbb8ea88d6c64f",
+        35,
+    ),
+    (
+        # Strip tags first, then unescape. Unescaping first would turn this
+        # escaped markup into real tags and delete the text.
+        "escaped markup is content, not tags",
+        {"title": "Escaped", "tags": "", "text": "&lt;b&gt;not a tag&lt;/b&gt;"},
+        "a758e80e1119052a28e974bd8d1ad0877967624298e8ac78749dbbc8a957cb9e",
+        25,
+    ),
+    (
+        # Truncation counts characters, matching the CMS's rune-wise cut. A
+        # byte-wise cut on either side would land mid-character.
+        "long multi-byte body truncates by character",
+        {"title": "Long", "tags": "", "text": "<p>" + ("xé " * 4000) + "</p>"},
+        "3a05bd7c947bd63317524a41c5e75e8b5cf6b711ba6554d515f475067e93a949",
+        5000,
+    ),
+    (
+        "an entirely empty article",
+        {"title": "", "tags": "", "text": "<p></p>"},
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        0,
+    ),
+    (
+        "numeric and named entities in tags and body",
+        {"title": "Entities", "tags": "a&amp;b", "text": "<p>&nbsp;&#39;quoted&#39;</p>"},
+        "e7da0a366df46c77542065f919a89e4267b30cc5030c5f206ca60b69a6a3b356",
+        27,
+    ),
+]
+
+
+def formatter(rows=None):
+    return ArticleEmbeddingsFormatter(
+        rows or [], model="BAAI/bge-small-en-v1.5", batch_size=8, max_chars=MAX_CHARS
+    )
+
+
+class EmbeddingSourceMatchesCMS(unittest.TestCase):
+    def test_goldens(self):
+        fmt = formatter()
+        for name, row, want_hash, want_len in GOLDENS:
+            with self.subTest(name):
+                blob = fmt._embedding_source(row)
+                self.assertEqual(len(blob), want_len, blob)
+                got = hashlib.sha256(blob.encode("utf-8")).hexdigest()
+                self.assertEqual(got, want_hash, blob)
+
+
+class NormalizeArticles(unittest.TestCase):
+    def test_carries_the_hash_and_skips_unusable_rows(self):
+        fmt = formatter([
+            {"id": 2, "title": "Second", "tags": "", "text": "<p>b</p>"},
+            {"id": 1, "title": "First", "tags": "", "text": "<p>a</p>"},
+            {"id": None, "title": "No id", "tags": "", "text": "<p>c</p>"},
+            {"id": "not-a-number", "title": "Bad id", "tags": "", "text": "<p>d</p>"},
+            {"id": 3, "title": "", "tags": "", "text": "<p></p>"},
+        ])
+        rows = fmt._normalize_articles()
+
+        # Sorted by id, and the three unusable rows are gone: no id, an
+        # unparseable id, and one with no text to embed at all.
+        self.assertEqual([row["id"] for row in rows], [1, 2])
+        for row in rows:
+            self.assertEqual(
+                row["hash"], hashlib.sha256(row["text"].encode("utf-8")).hexdigest()
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Companion to **DrexelTriangle/triangle-cms#158** — these must merge together.

The CMS now owns `article_embeddings`: it creates the table and runs a background reconciler that fills in anything missing or stale. This formatter stays because embedding ~10k archived articles in one batched process is far faster than draining them through the CMS's embedding sidecar — but it is now an optimization, not the source of truth.

## Safe to run against a live table

- **No more `DROP TABLE`.** Dropping on every reseed is exactly what wiped every vector the CMS had written since the last one — and nothing ever refilled them, so those articles silently dropped out of related-articles. Rows are now upserted into a `CREATE TABLE IF NOT EXISTS` matching the CMS's canonical schema.
- **Each row carries its source hash and model name.** That is what lets the reconciler tell "already embedded with the current model" from "needs work". Without it every seeded row looks unattributed and the archive gets re-embedded through the sidecar after each reseed.
- **The embedded text matches the CMS byte for byte.** Now `title + tags + body` (was `title + description + body`), HTML-stripped in the same order: strip tags → unescape entities → collapse whitespace. The order is part of the contract — unescaping first would let an escaped `&lt;b&gt;` become a tag and get deleted.

The same seven golden hashes are pinned here and in the CMS, covering unicode, named/numeric entities, and the 5000-character truncation (characters here, runes there — a byte-wise cut on either side would land mid-character). If the two implementations drift, these tests fail instead of the reconciler quietly re-embedding the whole archive.

## Model change

`sentence-transformers/paraphrase-MiniLM-L3-v2` → `BAAI/bge-small-en-v1.5`. The old one is a symmetric paraphrase model being used for query→document retrieval, which is not what it was trained for. Both are 384-dim, so `VECTOR(384)` is unchanged.

This must match the CMS sidecar's `EMBED_MODEL`. A distance between vectors from two different models is meaningless, so a mismatch degrades ranking silently rather than failing.

Embeddings are also **normalized** now. MariaDB ranks by euclidean distance, which only agrees with cosine similarity on unit vectors — leaving them unnormalized let a long article's larger magnitude skew every ranking it appeared in, including the existing related-articles feature.

## Note for the reseed runbook

Because the model changed, existing prod vectors are stale in a way the reconciler cannot detect (they predate hash bookkeeping, so it deliberately leaves them alone). The CMS PR's deploy notes call for a one-time `TRUNCATE TABLE article_embeddings` after rollout; after that, either this formatter or the reconciler can refill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)