### PR TITLE
Stop dropping sudoku posts from the corpus

### DIFF
--- a/Translator/ArticleTranslator.py
+++ b/Translator/ArticleTranslator.py
@@ -55,10 +55,15 @@ class ArticleTranslator(Translator):
     lengthCheck = 4 if debugMode else 100
     isTextNotNull = text != Article.defaultValue and len(text) >= lengthCheck
     isTitleNotNull = title != Article.defaultValue
-    isTextNotSudoku = isTextNotNull and ('sudoku' not in text)
     isTitleNotUnderscore = isTitleNotNull and ('_' not in title)
 
-    return isTextNotSudoku and isTitleNotUnderscore
+    # There used to be a `'sudoku' not in text` drop here, alongside the
+    # crossword/comics category drop already removed from _processTags.
+    # Production publishes sudoku, so it belongs in the corpus -- and the check
+    # was on the BODY, so it also silently dropped any article that merely
+    # mentioned the word. Its only visible effect was an empty Sudoku
+    # subsection that looked like a broken section page rather than a filter.
+    return isTextNotNull and isTitleNotUnderscore
 
   def _normalizeCommentStatus(self, value):
     # WordPress exports carry inconsistent casing/whitespace for comment_status


### PR DESCRIPTION
Found while investigating why the Sudoku subsection was empty on the dev site (see DrexelTriangle/triangle-cms#174 for the rest of that investigation).

## The bug

`_dataSanityCheck` rejected any post whose body contained `"sudoku"`:

```python
isTextNotSudoku = isTextNotNull and ('sudoku' not in text)
```

So no sudoku article ever reached the database — there are currently **zero** in the live corpus. The CMS has a Sudoku subsection under Comics & Puzzles; it reads 0 and its page is empty, which reads as a broken section rather than a deliberate filter.

Production publishes sudoku, so it belongs in the corpus. Same call as the crossword/comics category drop already removed from `_processTags`.

The check was also broader than its name suggests: it tested the **body**, not the category or title, so an article that merely mentioned the word in passing was dropped too.

## Note

`Translator/Article.py` still carries its own copy of this check *and* of the old crossword/comics drop. It's dead code — only its `defaultValue` constant is referenced — so it's left alone here, but it's a trap for whoever greps for these next.

## Effect

Nothing changes until the next reseed; the Sudoku subsection stays empty until then.

60 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)