### PR TITLE
Resolve featured images and recover pre-2020 bylines

### DIFF
--- a/Extractor.py
+++ b/Extractor.py
@@ -3,13 +3,15 @@ from contextlib import contextmanager
 
 from lxml import etree  # type: ignore[attr-defined]
 from Utils.Utility import Utility as U
-from Utils.Constants import EXPORT_DIR
+from Utils.Constants import EXPORT_DIR, THUMBNAIL_META_KEY
 
 # Sentinel for "key absent" so dict values of None are handled correctly.
 _MISSING = object()
 
 _POST_ITEM_KEYS = frozenset((
   "content:encoded",
+  # The byline for every pre-Co-Authors-Plus post; without it they are authorless.
+  "dc:creator",
   "wp:comment_status",
   "description",
   "wp:post_id",
@@ -19,6 +21,10 @@ _POST_ITEM_KEYS = frozenset((
   "category",
   "wp:postmeta",
   "title",
+  # Attachment <item>s ride in the same list; these two are what a featured
+  # image resolves through (see ArticleTranslator.resolveFeaturedImages).
+  "wp:post_type",
+  "wp:attachment_url",
 ))
 _GUEST_AUTHOR_ITEM_KEYS = frozenset(("wp:postmeta",))
 _AUTHOR_KEYS = frozenset((
@@ -31,15 +37,20 @@ _AUTHOR_KEYS = frozenset((
 
 _WP_NS = "http://wordpress.org/export/1.2/"
 _CONTENT_NS = "http://purl.org/rss/1.0/modules/content/"
+_DC_NS = "http://purl.org/dc/elements/1.1/"
 _CONTENT_ENCODED_TAG = f"{{{_CONTENT_NS}}}encoded"
+_DC_CREATOR_TAG = f"{{{_DC_NS}}}creator"
 _WP_POSTMETA_TAG = f"{{{_WP_NS}}}postmeta"
 _WP_POST_TYPE_TAG = f"{{{_WP_NS}}}post_type"
+_WP_POST_ID_TAG = f"{{{_WP_NS}}}post_id"
+_WP_ATTACHMENT_URL_TAG = f"{{{_WP_NS}}}attachment_url"
 _WP_META_KEY_TAG = f"{{{_WP_NS}}}meta_key"
 _WP_META_VALUE_TAG = f"{{{_WP_NS}}}meta_value"
 _ARTICLE_SCALAR_TAGS = {
   "title": "title",
   "description": "description",
   _CONTENT_ENCODED_TAG: "content:encoded",
+  _DC_CREATOR_TAG: "dc:creator",
   f"{{{_WP_NS}}}comment_status": "wp:comment_status",
   f"{{{_WP_NS}}}post_id": "wp:post_id",
   f"{{{_WP_NS}}}post_name": "wp:post_name",
@@ -261,11 +272,9 @@ class Extractor:
     return meta_key, {"wp:meta_key": meta_key, "wp:meta_value": meta_value}
 
   def _articleItemToObj(self, elem):
-    # ~half of all <item>s are attachments (media), never articles; bail before
-    # the expensive content normalization/tag/metadata build so they cost only
-    # one tag scan instead of a full translate that _shouldSkip would discard.
-    if elem.findtext(_WP_POST_TYPE_TAG) != "post":
-      return None
+    # Callers must have checked wp:post_type == "post" first: ~half of all
+    # <item>s are attachments (media), never articles, and they must cost one
+    # tag scan rather than a full content normalization/tag/metadata build.
     result = {}
     for child in elem:
       tag = child.tag
@@ -276,9 +285,25 @@ class Extractor:
         self._appendValue(result, "category", self._categoryToObj(child))
       elif tag == _WP_POSTMETA_TAG:
         meta_key, value = self._postmetaPair(child)
-        if isinstance(meta_key, str) and "yoast" in meta_key:
+        if isinstance(meta_key, str) and ("yoast" in meta_key or meta_key == THUMBNAIL_META_KEY):
           self._appendValue(result, "wp:postmeta", value)
     return result
+
+  def _attachmentURLPair(self, elem):
+    """(attachment post id, file URL) for a media <item>.
+
+    A post's featured image is only ever a `_thumbnail_id` pointing at one of
+    these ids, so this index is what turns that id back into a usable URL.
+    """
+    postID = None
+    url = None
+    for child in elem:
+      tag = child.tag
+      if tag == _WP_POST_ID_TAG:
+        postID = self._textValue(child)
+      elif tag == _WP_ATTACHMENT_URL_TAG:
+        url = self._textValue(child)
+    return postID, url
 
   def _authorToObj(self, elem):
     result = {}
@@ -344,13 +369,21 @@ class Extractor:
   def _translatePosts(self, path, articleTranslator, authorTranslator):
     self._keyCache = {}
     self._attrCache = {}
+    # Attachments are interleaved with (and usually follow) the posts that
+    # reference them, so featured images can only be resolved once the whole
+    # file has been streamed. Returned for that second, in-memory pass.
+    attachmentURLs = {}
     with self._openXml(path) as handle:
       context = etree.iterparse(handle, events=("end",), tag=("item", "{*}author"), recover=True)
       for _, elem in context:
         if elem.tag == "item":
-          obj = self._articleItemToObj(elem)
-          if obj is not None:
-            articleTranslator.translateItem(obj)
+          postType = elem.findtext(_WP_POST_TYPE_TAG)
+          if postType == "post":
+            articleTranslator.translateItem(self._articleItemToObj(elem))
+          elif postType == "attachment":
+            postID, url = self._attachmentURLPair(elem)
+            if postID and url:
+              attachmentURLs[postID] = url
         else:
           authorTranslator.translateItem(self._authorToObj(elem))
         elem.clear()
@@ -358,6 +391,7 @@ class Extractor:
         if parent is not None:
           while elem.getprevious() is not None:
             del parent[0]
+    return attachmentURLs
 
   def _translateGuestAuthors(self, path, guestAuthorTranslator):
     self._keyCache = {}
@@ -384,7 +418,9 @@ class Extractor:
     translators["articles"].guestAuthorNames = self.buildGuestAuthorNameMap(self.guestAuthsFile)
 
     progress("parsing/translating wp-posts.xml")
-    self._translatePosts(self.postsFile, translators["articles"], translators["auth"])
+    attachmentURLs = self._translatePosts(self.postsFile, translators["articles"], translators["auth"])
+    progress("resolving featured images")
+    translators["articles"].resolveFeaturedImages(attachmentURLs)
     progress("parsing/translating wp-guestAuths.xml")
     self._translateGuestAuthors(self.guestAuthsFile, translators["gAuth"])
     return translators

--- a/Translator/ArticleTranslator.py
+++ b/Translator/ArticleTranslator.py
@@ -2,6 +2,7 @@ from pathlib import Path
 import json
 from Translator.Translator import Translator
 from Translator.Article import Article
+from Utils.Constants import THUMBNAIL_META_KEY
 from Utils.Utility import Utility as U
 import re
 
@@ -23,13 +24,16 @@ class ArticleTranslator(Translator):
       "authorCleanNames": [],
       "breakingNews": False,
       "commentStatus": self._normalizeCommentStatus(data.get('wp:comment_status')),
+      "creator": data.get('dc:creator'),
       "description": U._html_text_norm(data.get('description')),
-      "featuredImgID": -1,
+      "featuredImgID": self._thumbnailID(data.get('wp:postmeta')),
       "id": self.objCount,
       "slug": data.get('wp:post_name', Article.defaultValue),
       "wpPostID": self._normalizeInt(data.get('wp:post_id')),
       "priority": False,
       "modDate": data.get('wp:post_modified_gmt', Article.defaultValue),
+      # Fallback only: overwritten by the post's featured image, if it has one,
+      # once the attachments have been indexed (resolveFeaturedImages).
       "photoURL": self._checkForImg(text),
       "pubDate": data.get('wp:post_date_gmt', Article.defaultValue),
       "tags": data.get('category'),
@@ -90,6 +94,43 @@ class ArticleTranslator(Translator):
     except (TypeError, ValueError):
       return None
   
+  def _thumbnailID(self, metadata):
+    """The `_thumbnail_id` postmeta value, or -1 when the post has no featured
+    image. -1 is WordPress' own "unset" sentinel and what this field carried
+    before featured images were read at all."""
+    if isinstance(metadata, dict):
+      metadata = [metadata]
+    elif not isinstance(metadata, list):
+      return -1
+
+    for itm in metadata:
+      if isinstance(itm, dict) and itm.get('wp:meta_key') == THUMBNAIL_META_KEY:
+        thumbnailID = self._normalizeInt(itm.get('wp:meta_value'))
+        if thumbnailID is not None:
+          return thumbnailID
+    return -1
+
+  def resolveFeaturedImages(self, attachmentURLs):
+    """Set `photoURL` from the post's WordPress featured image.
+
+    `_thumbnail_id` is what the live site renders as an article's image, so it
+    is the authority here. The `_checkForImg` body scan is only a fallback for
+    the posts that have no featured image set -- it picks whatever image happens
+    to appear first in the body, which is frequently not the same picture, and
+    for a post whose body is a single [puzzleme] shortcode (every modern sudoku
+    and crossword) it finds nothing at all.
+    """
+    if not attachmentURLs:
+      return 0
+
+    resolved = 0
+    for obj in self.objDataDict.values():
+      url = attachmentURLs.get(str(obj.get("featuredImgID")))
+      if url:
+        obj["photoURL"] = url
+        resolved += 1
+    return resolved
+
   def _checkForImg(self, text:str):
     matchObj = _IMG_UPLOAD_PATTERN.search(text) 
     if matchObj:
@@ -141,6 +182,39 @@ class ArticleTranslator(Translator):
     resultCategories.sort(reverse=True)
     obj["tags"] = resultTags
     obj["categories"] = resultCategories
+    self._applyCreatorFallback(obj)
+
+  def _applyCreatorFallback(self, obj):
+    """Use `<dc:creator>` as the byline when the post has no author term.
+
+    Co-Authors Plus writes `<category domain="author">` terms, but 2651 of the
+    10128 posts in the Aug 2026 export -- 26%, concentrated pre-2020 -- predate
+    the plugin and carry their author ONLY in `dc:creator`. Reading just the
+    terms left every one of them with no byline at all, which is the entire
+    "~2635 authorless articles" figure, and it was never irreducible: 2646 of
+    the 2651 handles resolve to an author record that already exists.
+
+    The handle is a login (`john.chagaris`), not a display name, so it is fed in
+    as a clean name only. ArticleAuthorMatcher resolves that against the authors
+    list and overwrites `authors`/`authorIDs` with the real display name, which
+    keeps the two columns and the articles_authors join in sync.
+    """
+    if obj["authorCleanNames"]:
+      return
+
+    creator = obj.get("creator")
+    if not isinstance(creator, str) or not creator.strip():
+      return
+
+    # A handful of handles are full addresses (`a.b@dev.thetriangle.org`); the
+    # local part is the login that matches an author record.
+    handle = creator.strip().split("@", 1)[0]
+    cleanName = handle.translate(str.maketrans('', '', '.-_ ')).lower()
+    if not cleanName:
+      return
+
+    obj["authorCleanNames"].append(cleanName)
+    obj["authors"].append(handle)
 
   def _processMetadata(self, obj):
     collection = {}
@@ -167,8 +241,20 @@ class ArticleTranslator(Translator):
     debugMode = False
     if on_progress:
       on_progress(f"translating {len(self.source)} articles")
+    # Attachment <item>s share the source list with the posts; they are not
+    # articles, but they hold the URLs the featured images resolve through.
+    attachmentURLs = {}
     for itm in self.source:
+      postType = itm.get('wp:post_type') if isinstance(itm, dict) else None
+      if postType == 'attachment':
+        postID, url = itm.get('wp:post_id'), itm.get('wp:attachment_url')
+        if postID and url:
+          attachmentURLs[str(postID).strip()] = url
+        continue
       self.translateItem(itm, debugMode)
+    if on_progress:
+      on_progress("resolving featured images")
+    self.resolveFeaturedImages(attachmentURLs)
 
   def translateItem(self, itm, debugMode=False):
     obj = self._getArticleData(itm)

--- a/Utils/Constants.py
+++ b/Utils/Constants.py
@@ -7,3 +7,7 @@ EXPORT_DIR = DATA_DIR / "wp-export"
 POSTS_FILE = EXPORT_DIR / "wp-posts.xml"
 GUEST_AUTH_FILE = EXPORT_DIR / "wp-guestAuths.xml"
 UNZIPPED_FILES = [POSTS_FILE, GUEST_AUTH_FILE]
+
+# WordPress stores a post's featured image as this postmeta key, whose value is
+# the post id of the attachment <item> holding the actual file URL.
+THUMBNAIL_META_KEY = "_thumbnail_id"

--- a/tests/test_creator_byline.py
+++ b/tests/test_creator_byline.py
@@ -1,0 +1,66 @@
+"""Tests for the <dc:creator> byline fallback.
+
+Run from the repo root:
+
+    .venv/bin/python -m unittest tests.test_creator_byline
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from Translator.ArticleTranslator import ArticleTranslator
+
+
+def author_term(nicename, text):
+    return {"@domain": "author", "@nicename": nicename, "#text": text}
+
+
+def article_obj(terms, creator=None, text="x" * 200):
+    return {
+        "tags": terms,
+        "categories": [],
+        "text": text,
+        "title": "A title",
+        "creator": creator,
+        "authors": [],
+        "authorCleanNames": [],
+    }
+
+
+class CreatorFallback(unittest.TestCase):
+    def setUp(self):
+        self.translator = ArticleTranslator([])
+
+    def test_creator_supplies_the_byline_when_there_is_no_author_term(self):
+        # The regression: 2651 pre-Co-Authors-Plus posts carry their byline only
+        # here, and every one of them used to come out with no author at all.
+        obj = article_obj([], creator="john.chagaris")
+        self.translator._processTags(obj)
+        self.assertEqual(obj["authorCleanNames"], ["johnchagaris"])
+        self.assertEqual(obj["authors"], ["john.chagaris"])
+
+    def test_author_term_wins_and_creator_is_not_added(self):
+        # Posts that have both must not gain a second, duplicate byline.
+        self.translator.guestAuthorNames = {"cap-beeboop": "Michael Davis"}
+        obj = article_obj([author_term("cap-beeboop", "beeboop")], creator="someone.else")
+        self.translator._processTags(obj)
+        self.assertEqual(obj["authors"], ["Michael Davis"])
+        self.assertEqual(obj["authorCleanNames"], ["michaeldavis"])
+
+    def test_email_shaped_handles_use_the_local_part(self):
+        obj = article_obj([], creator="stefan.kusmirek@dev.thetriangle.org")
+        self.translator._processTags(obj)
+        self.assertEqual(obj["authorCleanNames"], ["stefankusmirek"])
+
+    def test_missing_or_blank_creator_is_left_alone(self):
+        for value in (None, "", "   ", 12345):
+            obj = article_obj([], creator=value)
+            self.translator._processTags(obj)
+            self.assertEqual(obj["authorCleanNames"], [], f"for {value!r}")
+            self.assertEqual(obj["authors"], [], f"for {value!r}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_featured_images.py
+++ b/tests/test_featured_images.py
@@ -1,0 +1,176 @@
+"""Tests for resolving a post's WordPress featured image into photo_url.
+
+Run from the repo root:
+
+    .venv/bin/python -m unittest tests.test_featured_images
+"""
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from Extractor import Extractor
+from Translator.ArticleTranslator import ArticleTranslator
+from Translator.AuthorTranslator import AuthorTranslator
+
+
+def meta(key, value):
+    return {"wp:meta_key": key, "wp:meta_value": value}
+
+
+WXR = """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"
+  xmlns:content="http://purl.org/rss/1.0/modules/content/"
+  xmlns:wp="http://wordpress.org/export/1.2/">
+<channel>
+  <item>
+    <title>Here's your Sudoku :)</title>
+    <content:encoded><![CDATA[[puzzleme set="abc" id="def" type="sudoku"]{filler}]]></content:encoded>
+    <wp:post_id>59171</wp:post_id>
+    <wp:post_name>heres-your-sudoku</wp:post_name>
+    <wp:post_type>post</wp:post_type>
+    <wp:post_date_gmt>2023-11-17 14:00:00</wp:post_date_gmt>
+    <wp:post_modified_gmt>2023-11-17 14:00:00</wp:post_modified_gmt>
+    <wp:comment_status>open</wp:comment_status>
+    <category domain="category" nicename="sudoku">Sudoku</category>
+    <wp:postmeta>
+      <wp:meta_key>_thumbnail_id</wp:meta_key>
+      <wp:meta_value>59172</wp:meta_value>
+    </wp:postmeta>
+  </item>
+  <item>
+    <title>Body image loses to the featured image</title>
+    <content:encoded><![CDATA[<img src="https://www.thetriangle.org/wp-content/uploads/2023/11/in-body.jpg" />{filler}]]></content:encoded>
+    <wp:post_id>59180</wp:post_id>
+    <wp:post_name>featured-image-wins</wp:post_name>
+    <wp:post_type>post</wp:post_type>
+    <wp:post_date_gmt>2023-11-18 14:00:00</wp:post_date_gmt>
+    <wp:post_modified_gmt>2023-11-18 14:00:00</wp:post_modified_gmt>
+    <wp:comment_status>open</wp:comment_status>
+    <category domain="category" nicename="news">News</category>
+    <wp:postmeta>
+      <wp:meta_key>_thumbnail_id</wp:meta_key>
+      <wp:meta_value>59172</wp:meta_value>
+    </wp:postmeta>
+  </item>
+  <item>
+    <title>No featured image at all</title>
+    <content:encoded><![CDATA[<img src="https://www.thetriangle.org/wp-content/uploads/2023/11/only-image.jpg" />{filler}]]></content:encoded>
+    <wp:post_id>59190</wp:post_id>
+    <wp:post_name>no-featured-image</wp:post_name>
+    <wp:post_type>post</wp:post_type>
+    <wp:post_date_gmt>2023-11-19 14:00:00</wp:post_date_gmt>
+    <wp:post_modified_gmt>2023-11-19 14:00:00</wp:post_modified_gmt>
+    <wp:comment_status>open</wp:comment_status>
+    <category domain="category" nicename="news">News</category>
+  </item>
+  <item>
+    <title>Screenshot 2023-11-14 123323</title>
+    <content:encoded></content:encoded>
+    <wp:post_id>59172</wp:post_id>
+    <wp:post_name>screenshot-2023-11-14-123323</wp:post_name>
+    <wp:post_type>attachment</wp:post_type>
+    <wp:post_parent>59171</wp:post_parent>
+    <wp:attachment_url>https://cms.thetriangle.org/wp-content/uploads/2023/11/sudoku.png</wp:attachment_url>
+  </item>
+</channel>
+</rss>
+""".replace("{filler}", "x" * 200)
+
+
+class ThumbnailIDExtraction(unittest.TestCase):
+    def setUp(self):
+        self.translator = ArticleTranslator([])
+
+    def test_reads_the_thumbnail_postmeta(self):
+        self.assertEqual(self.translator._thumbnailID([meta("_thumbnail_id", "59172")]), 59172)
+
+    def test_single_postmeta_arrives_as_a_bare_dict(self):
+        self.assertEqual(self.translator._thumbnailID(meta("_thumbnail_id", "42")), 42)
+
+    def test_missing_or_unusable_meta_keeps_the_wordpress_sentinel(self):
+        self.assertEqual(self.translator._thumbnailID([meta("_edit_last", "101266")]), -1)
+        self.assertEqual(self.translator._thumbnailID([meta("_thumbnail_id", "")]), -1)
+        self.assertEqual(self.translator._thumbnailID(None), -1)
+
+
+class ResolveFeaturedImages(unittest.TestCase):
+    def setUp(self):
+        self.translator = ArticleTranslator([])
+
+    def _addArticle(self, articleID, featuredImgID, photoURL=None):
+        self.translator.addObject({"id": articleID, "featuredImgID": featuredImgID, "photoURL": photoURL})
+
+    def test_fills_in_a_missing_photo(self):
+        self._addArticle(0, 59172)
+        resolved = self.translator.resolveFeaturedImages({"59172": "https://cms.thetriangle.org/x.png"})
+        self.assertEqual(resolved, 1)
+        self.assertEqual(self.translator.objDataDict[0]["photoURL"], "https://cms.thetriangle.org/x.png")
+
+    def test_featured_image_beats_the_first_image_in_the_body(self):
+        # The body scan takes whatever image comes first, which for ~2,200
+        # articles is not the picture the live site shows.
+        self._addArticle(0, 59172, photoURL="wp-content/uploads/2023/11/in-body.jpg")
+        self.assertEqual(self.translator.resolveFeaturedImages({"59172": "https://cms.thetriangle.org/x.png"}), 1)
+        self.assertEqual(self.translator.objDataDict[0]["photoURL"], "https://cms.thetriangle.org/x.png")
+
+    def test_unset_or_dangling_thumbnail_keeps_the_body_image(self):
+        # No featured image (or one whose attachment is gone from the export):
+        # the body scan is all there is, and it must survive.
+        self._addArticle(0, -1, photoURL="wp-content/uploads/2023/11/in-body.jpg")
+        self._addArticle(1, 99999)
+        self.assertEqual(self.translator.resolveFeaturedImages({"59172": "https://cms.thetriangle.org/x.png"}), 0)
+        self.assertEqual(self.translator.objDataDict[0]["photoURL"], "wp-content/uploads/2023/11/in-body.jpg")
+        self.assertIsNone(self.translator.objDataDict[1]["photoURL"])
+
+
+class ExtractAndResolve(unittest.TestCase):
+    """The regression end to end: the attachment <item> is streamed *after* the
+    post that points at it, so the fix only works if resolution happens once the
+    whole file has been read."""
+
+    def setUp(self):
+        self.tempDir = tempfile.TemporaryDirectory()
+        self.postsPath = Path(self.tempDir.name) / "wp-posts.xml"
+        self.postsPath.write_text(WXR, encoding="utf-8")
+        self.addCleanup(self.tempDir.cleanup)
+
+    def _translate(self):
+        articles = ArticleTranslator([])
+        extractor = Extractor(str(self.postsPath), str(self.postsPath))
+        attachmentURLs = extractor._translatePosts(str(self.postsPath), articles, AuthorTranslator([]))
+        articles.resolveFeaturedImages(attachmentURLs)
+        return {obj["slug"]: obj for obj in articles.getObjList()}
+
+    def test_shortcode_only_post_gets_its_featured_image(self):
+        article = self._translate()["heres-your-sudoku"]
+        self.assertEqual(article["featuredImgID"], 59172)
+        self.assertEqual(
+            article["photoURL"],
+            "https://cms.thetriangle.org/wp-content/uploads/2023/11/sudoku.png",
+        )
+
+    def test_featured_image_replaces_the_body_image(self):
+        article = self._translate()["featured-image-wins"]
+        self.assertEqual(
+            article["photoURL"],
+            "https://cms.thetriangle.org/wp-content/uploads/2023/11/sudoku.png",
+        )
+
+    def test_body_image_is_kept_when_no_featured_image_is_set(self):
+        article = self._translate()["no-featured-image"]
+        self.assertEqual(article["featuredImgID"], -1)
+        self.assertEqual(article["photoURL"], "wp-content/uploads/2023/11/only-image.jpg")
+
+    def test_attachments_are_not_translated_as_articles(self):
+        self.assertEqual(
+            sorted(self._translate()),
+            ["featured-image-wins", "heres-your-sudoku", "no-featured-image"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two gaps in what the ETL reads out of the WordPress export. Both left articles visibly incomplete in the CMS, and both are about fields the export always carried but the pipeline never looked at.

## Featured images

`photoURL` was only ever guessed by scanning the article body for the first uploaded image. The post's actual featured image was never read at all — `featuredImgID` was hardcoded to `-1`.

WordPress stores the featured image as a `_thumbnail_id` postmeta whose value points at an attachment `<item>` elsewhere in the same file, so resolving it needs both halves: the meta key is now kept during extraction, and attachment id → URL pairs are indexed as they stream past. Attachments are interleaved with (and usually follow) the posts referencing them, so the mapping can only be applied after the whole file has been read — hence the second in-memory pass in `resolveFeaturedImages`.

The body scan stays as a fallback for posts with no featured image set, but the two were never equivalent. The scan takes whatever image appears first in the body, frequently not the same picture, and for a post whose body is a single `[puzzleme]` shortcode — every modern sudoku and crossword — it finds nothing at all. That's the other half of the puzzle-content problem #59 started on: those posts now reach the corpus *and* arrive with their image.

## Pre-2020 bylines

Only Co-Authors Plus `<category domain="author">` terms were read. **2651 of the 10128 posts** in the Aug 2026 export — 26%, concentrated pre-2020 — predate that plugin and carry their author only in `<dc:creator>`, so every one came through with no byline.

That accounts for the entire "~2635 authorless articles" figure, and it was never irreducible: **2646 of the 2651** handles resolve to an author record that already exists.

`dc:creator` holds a login (`john.chagaris`), not a display name, so it's fed in as a clean name only and left for `ArticleAuthorMatcher` to resolve against the authors list. That keeps `authors`/`authorIDs` and the `articles_authors` join in sync, rather than seeding a display name that matches nothing.

## Notes for review

- `Extractor._articleItemToObj` no longer early-returns on non-posts; the caller now branches on `wp:post_type` because it has to route posts and attachments differently. The comment moved with the responsibility, and the cost profile is unchanged — attachments still cost one tag scan, not a full translate.
- `ArticleTranslator.translate` gets the equivalent attachment handling for callers that pass an already-materialized source list rather than streaming.
- These are two logically separate changes that ended up interleaved across the same files (both touch `Extractor.py` and `ArticleTranslator.py`), so they're one commit. Happy to split if you'd rather review them apart.

## Testing

New `tests/test_featured_images.py` and `tests/test_creator_byline.py`. All 12 test modules pass. Note there's no single command that runs the suite — no `tests/__init__.py`, so discovery fails and modules run one at a time by module path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)