### PR TITLE
Lift the Yoast SEO fields into their own article columns

### DIFF
--- a/Formatter/ArticleFormatter.py
+++ b/Formatter/ArticleFormatter.py
@@ -24,6 +24,9 @@ class ArticleFormatter(Formatter):
         "text",
         "excerpt",
         "title",
+        "focus_keyword",
+        "meta_description",
+        "seo_title",
     ]
     CMS_SCHEMA = {
         "id": "BIGINT PRIMARY KEY AUTO_INCREMENT",
@@ -45,6 +48,20 @@ class ArticleFormatter(Formatter):
         "text": "LONGTEXT",
         "excerpt": "LONGTEXT",
         "title": "LONGTEXT",
+        "focus_keyword": "LONGTEXT",
+        "meta_description": "LONGTEXT",
+        "seo_title": "LONGTEXT",
+    }
+
+    # Yoast keeps its editor fields in postmeta, which the translator collects
+    # into `metadata`. These three are the ones the CMS editor reads back, so
+    # they land in their own columns instead of only inside the metadata blob.
+    # Older posts wrote the keyphrase to the _text_input key, so it is a
+    # fallback rather than a separate field.
+    SEO_META_KEYS = {
+        "focus_keyword": ("_yoast_wpseo_focuskw", "_yoast_wpseo_focuskw_text_input"),
+        "meta_description": ("_yoast_wpseo_metadesc",),
+        "seo_title": ("_yoast_wpseo_title",),
     }
 
     def __init__(self, articleData):
@@ -57,6 +74,34 @@ class ArticleFormatter(Formatter):
         if value in (None, "", "0000-00-00", "0000-00-00 00:00:00"):
             return None
         return value
+
+    def _seo_columns(self, metadata):
+        # Yoast title/description templates ("%%title%% %%sep%% %%sitename%%")
+        # are placeholders WordPress expands at render time; they are noise once
+        # the post leaves WP, so they drop out rather than reaching an editor.
+        if isinstance(metadata, list):
+            merged = {}
+            for itm in metadata:
+                if isinstance(itm, dict):
+                    merged.update(itm)
+            metadata = merged
+        if not isinstance(metadata, dict):
+            metadata = {}
+
+        columns = {}
+        for column, keys in self.SEO_META_KEYS.items():
+            value = None
+            for key in keys:
+                candidate = metadata.get(key)
+                if not isinstance(candidate, str):
+                    continue
+                candidate = candidate.strip()
+                if not candidate or "%%" in candidate:
+                    continue
+                value = candidate
+                break
+            columns[column] = value
+        return columns
 
     def _to_cms_row(self, obj):
         creation_date = self._normalize_datetime(
@@ -79,7 +124,10 @@ class ArticleFormatter(Formatter):
         else:
             photo_url = None
 
+        metadata = obj.get("metadata")
+
         return {
+            **self._seo_columns(metadata),
             "id": obj.get("id"),
             "creation_date": creation_date,
             "slug": obj.get("slug"),
@@ -95,7 +143,7 @@ class ArticleFormatter(Formatter):
             "pub_date": self._normalize_datetime(obj.get("pubDate")),
             "tags": obj.get("tags"),
             "categories": obj.get("categories"),
-            "metadata": obj.get("metadata"),
+            "metadata": metadata,
             "text": obj.get("text"),
             "excerpt": obj.get("excerpt"),
             "title": obj.get("title"),

--- a/tests/test_article_seo_fields.py
+++ b/tests/test_article_seo_fields.py
@@ -1,0 +1,91 @@
+"""Tests for the Yoast SEO fields ArticleFormatter lifts into their own columns.
+Run from the repo root:
+
+    .venv/bin/python -m unittest tests.test_article_seo_fields
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from Formatter.ArticleFormatter import ArticleFormatter
+
+
+class SeoColumns(unittest.TestCase):
+    def _row(self, metadata):
+        return ArticleFormatter([])._to_cms_row({"metadata": metadata})
+
+    def test_yoast_keys_land_in_their_columns(self):
+        row = self._row({
+            "_yoast_wpseo_focuskw": "Soda Fest",
+            "_yoast_wpseo_metadesc": "A creative genius is impossible to stop.",
+            "_yoast_wpseo_title": "Store profile: Styles inspired by Marc",
+            "_yoast_wpseo_linkdex": "61",
+        })
+        self.assertEqual(row["focus_keyword"], "Soda Fest")
+        self.assertEqual(row["meta_description"], "A creative genius is impossible to stop.")
+        self.assertEqual(row["seo_title"], "Store profile: Styles inspired by Marc")
+
+    def test_legacy_text_input_key_fills_the_keyphrase(self):
+        # Older posts wrote the keyphrase only to the _text_input key.
+        row = self._row({"_yoast_wpseo_focuskw_text_input": "Drexel"})
+        self.assertEqual(row["focus_keyword"], "Drexel")
+
+    def test_canonical_key_wins_over_the_legacy_one(self):
+        row = self._row({
+            "_yoast_wpseo_focuskw": "current",
+            "_yoast_wpseo_focuskw_text_input": "stale",
+        })
+        self.assertEqual(row["focus_keyword"], "current")
+
+    def test_yoast_templates_are_dropped(self):
+        # "%%title%% %%sep%% %%sitename%%" only means something inside WordPress;
+        # importing it verbatim would put placeholder text in the CMS editor.
+        row = self._row({
+            "_yoast_wpseo_title": "%%title%% %%sep%% %%sitename%%",
+            "_yoast_wpseo_metadesc": "%%excerpt%%",
+        })
+        self.assertIsNone(row["seo_title"])
+        self.assertIsNone(row["meta_description"])
+
+    def test_blank_and_missing_metadata_are_null(self):
+        for metadata in ({}, None, "-1", [], {"_yoast_wpseo_focuskw": "   "}):
+            with self.subTest(metadata=metadata):
+                row = self._row(metadata)
+                self.assertIsNone(row["focus_keyword"])
+                self.assertIsNone(row["meta_description"])
+                self.assertIsNone(row["seo_title"])
+
+    def test_metadata_list_form_is_merged(self):
+        row = self._row([
+            {"_yoast_wpseo_focuskw": "girl"},
+            {"_yoast_wpseo_title": "The new IT girl"},
+        ])
+        self.assertEqual(row["focus_keyword"], "girl")
+        self.assertEqual(row["seo_title"], "The new IT girl")
+
+    def test_metadata_blob_is_still_emitted(self):
+        metadata = {"_yoast_wpseo_focuskw": "Drexel"}
+        self.assertEqual(self._row(metadata)["metadata"], metadata)
+
+    def test_columns_and_schema_stay_in_step(self):
+        for column in ("focus_keyword", "meta_description", "seo_title"):
+            self.assertIn(column, ArticleFormatter.CMS_COLUMNS)
+            self.assertIn(column, ArticleFormatter.CMS_SCHEMA)
+
+
+class SeoSql(unittest.TestCase):
+    def test_insert_carries_the_seo_values(self):
+        statements = list(ArticleFormatter([
+            {"id": 1, "title": "T", "metadata": {"_yoast_wpseo_focuskw": "Soda Fest"}}
+        ]).iter_format("articles"))
+        create, inserts = statements[0], "\n".join(statements[1:])
+        self.assertIn("`focus_keyword` LONGTEXT", create)
+        self.assertIn("`meta_description` LONGTEXT", create)
+        self.assertIn("`seo_title` LONGTEXT", create)
+        self.assertIn("Soda Fest", inserts)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The keyphrase, meta description and SEO title were reaching the CMS only inside the `metadata` blob, so the editor's SEO panel came up empty on every imported article — they all looked like they'd never been optimised. This gives them real columns (`focus_keyword`, `meta_description`, `seo_title`), which is where the CMS actually reads them from.

Three details:

- Older posts wrote the keyphrase to `_yoast_wpseo_focuskw_text_input` rather than `_yoast_wpseo_focuskw`, so that key is a fallback and the canonical one wins when both are present.
- Yoast title/description **templates** (`%%title%% %%sep%% %%sitename%%`) are placeholders WordPress expands at render time. They mean nothing outside WP, so they're dropped rather than imported verbatim into an editor field.
- `metadata` is still emitted unchanged — this lifts values out, it doesn't move them.

Wanted for the production cutover reseed, so imported articles arrive with their SEO fields populated.

Note for the reseed: the ETL DDL now emits these three columns itself, so they no longer need pre-applying before the backend's first boot — `EnsureArticlesSchema` will find them already there.

Tests: `python -m unittest` over the suite, 88 pass (8 new, covering both metadata shapes, the legacy key, template rejection, and CMS_COLUMNS/CMS_SCHEMA staying in step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)